### PR TITLE
Log Stream end

### DIFF
--- a/src/lib/logger/index.ts
+++ b/src/lib/logger/index.ts
@@ -35,7 +35,7 @@ export class Logger {
         this._stream = new PassThrough()
 
         for (let transport of this.transports) {
-            this._stream.pipe(transport.getStream())
+            this._stream.pipe(transport.getStream(), { end: false })
         }
 
         return this._stream


### PR DESCRIPTION
…losed when any of the connections are closed and therefore, prevent the remaining connections from having their messages written to the log transports. This change keeps the log stream from ending, so the remaining connections' logs are still captured